### PR TITLE
Add two tutorials, remove the HabitatSim dependency in quick_start.py

### DIFF
--- a/quick_start.py
+++ b/quick_start.py
@@ -1,5 +1,4 @@
 import habitat
-from habitat.sims.habitat_simulator.actions import HabitatSimActions
 import cv2
 
 
@@ -17,8 +16,9 @@ def example():
     env = habitat.Env(
         config=habitat.get_config("benchmark/nav/pointnav/pointnav_habitat_test.yaml")
     )
-
+    
     print("Environment creation successful")
+    print(f"Env Action Space:{env._task.action_space}")
     observations = env.reset()
     print("Destination, distance: {:3f}, theta(radians): {:.2f}".format(
         observations["pointgoal_with_gps_compass"][0],
@@ -32,21 +32,18 @@ def example():
         keystroke = cv2.waitKey(0)
 
         if keystroke == ord(FORWARD_KEY):
-            action = HabitatSimActions.move_forward
-            print("action: FORWARD")
+            action = "move_forward"
         elif keystroke == ord(LEFT_KEY):
-            action = HabitatSimActions.turn_left
-            print("action: LEFT")
+            action = "turn_left"
         elif keystroke == ord(RIGHT_KEY):
-            action = HabitatSimActions.turn_right
-            print("action: RIGHT")
+            action = 'turn_right'
         elif keystroke == ord(FINISH):
-            action = HabitatSimActions.stop
-            print("action: FINISH")
+            action = 'stop'
         else:
             print("INVALID KEY")
             continue
 
+        print(f"action:{action}")
         observations = env.step(action)
         count_steps += 1
 
@@ -58,7 +55,7 @@ def example():
     print("Episode finished after {} steps.".format(count_steps))
 
     if (
-        action == HabitatSimActions.stop
+        action == "stop"
         and observations["pointgoal_with_gps_compass"][0] < 0.2
     ):
         print("you successfully navigated to destination point")

--- a/tutorials/actions.md
+++ b/tutorials/actions.md
@@ -1,0 +1,104 @@
+# Habitat Action Introduction
+
+Action is the abstraction that agent can execute in the environment — such as moving forward, turning left, or stopping. In Habitat-Lab, an action is a command you give the agent during `env.step(action_name)`. The action is created, registered, and refered to in a config file(typically in `task/xxx.yaml`)
+
+## Action Creation and Use Pipeline
+
+1. Implement Action: An action used in navigation is a class inherited from `SimulatorTaskAction`, which must implement `step()` method. Typically we call simulator to set the pose of the robot:
+    ```python
+    def _strafe_body(
+        sim,
+        move_amount: float,
+        strafe_angle_deg: float,
+        noise_amount: float,
+    ):
+        # Get the state of the agent
+        agent_state = sim.get_agent_state()
+        # Convert from np.quaternion (quaternion.quaternion) to mn.Quaternion
+        normalized_quaternion = agent_state.rotation
+        agent_mn_quat = mn.Quaternion(
+            normalized_quaternion.imag, normalized_quaternion.real
+        )
+        forward = agent_mn_quat.transform_vector(-mn.Vector3.z_axis())
+        strafe_angle = np.random.uniform(
+            (1 - noise_amount) * strafe_angle_deg,
+            (1 + noise_amount) * strafe_angle_deg,
+        )
+        strafe_angle = mn.Deg(strafe_angle)
+        rotation = mn.Quaternion.rotation(strafe_angle, mn.Vector3.y_axis())
+        move_amount = np.random.uniform(
+            (1 - noise_amount) * move_amount, (1 + noise_amount) * move_amount
+        )
+        delta_position = rotation.transform_vector(forward) * move_amount
+        final_position = sim.pathfinder.try_step(  # type: ignore
+            agent_state.position, agent_state.position + delta_position
+        )
+        sim.set_agent_state(
+            final_position,
+            [*rotation.vector, rotation.scalar],
+            reset_sensors=False,
+        )
+    @habitat.registry.register_task_action
+    class StrafeLeft(SimulatorTaskAction):
+        def __init__(self, *args, config, sim, **kwargs):
+            super().__init__(*args, config=config, sim=sim, **kwargs)
+            self._sim = sim
+            self._move_amount = config.move_amount
+            self._noise_amount = config.noise_amount
+
+        def _get_uuid(self, *args, **kwargs) -> str:
+            return "strafe_left"
+
+        def step(self, *args, **kwargs):
+            print(
+                f"Calling {self._get_uuid()} d={self._move_amount}m noise={self._noise_amount}"
+            )
+            # This is where the code for the new action goes. Here we use a
+            # helper method but you could directly modify the simulation here.
+            _strafe_body(self._sim, self._move_amount, 90, self._noise_amount)
+    ```
+    The decorator register the action we defined so that it can be found by thb config.
+
+2. Create a structured config pointing to our action
+    ```python
+    from habitat.config.default_structured_configs import ActionConfig
+    @dataclass
+    class StrafeActionConfig(ActionConfig):
+        type: str = "StrafeLeft"  # MUST match the registered action
+        move_amount: float = 0.25
+        noise_amount: float = 0.0
+    ```
+3. Store it to ConfigStore
+    ```python
+    from hydra.core.config_store import ConfigStore
+
+    cs = ConfigStore.instance()
+    cs.store(group="habitat/task/actions", name="strafe_action", node=StrafeActionConfig)
+    ```
+    > You can also use it directly in code, just like any other config.
+4. Refer it in yaml
+    ```yaml
+    defaults:
+    - habitat/task/actions@STRAFE_LEFT: strafe_action
+    ```
+5. Use it to step:
+    ```python
+    # First Load the yaml
+    obs = env.step("STRAFE_LEFT")
+    ```
+
+## Default Actions for Navigation
+
+There are 4 default actions defined in Habitat Sim and they are registered and stored in Habitat Lab, you can directly use them in your yaml and code:
+```yaml
+defaults:
+  - task_config_base
+  - actions:
+    - stop
+    - move_forward
+    - turn_left
+    - turn_right
+```
+```python
+env.step('stop')
+```

--- a/tutorials/config_stucture.md
+++ b/tutorials/config_stucture.md
@@ -1,0 +1,114 @@
+# Habitat Config Introduction
+
+Habitat V0.3.3 uses Hydra as the config framework. For official config system introduction, see [here](https://github.com/facebookresearch/habitat-lab/tree/main/habitat-lab/habitat/config).
+
+## Key Concepts
+- **Input Config**: Input config is the config that direcly read by our scripts, say, `config/benchmark/nav/pointnav/pointnav_habitat_test.yaml`.
+- **Output Config**: After the input config read by our scripts, the subconfig composited in the input config, and new configs given at running time will be merged by Hydra. Finally we will get an output config, where only basic types(int, str, etc) exists.
+- **Structured Config**: Structured Config provides a way to explicitly define some key-value pairs with the type. e.g.
+    ```python
+    @dataclass
+    class MyConfig:
+        learning_rate: float = 0.001
+        batch_size: int = 32
+        use_gpu: bool = True
+    ```
+    you can find basic structured config used in habitat [here](https://github.com/facebookresearch/habitat-lab/blob/main/habitat-lab/habitat/config/default_structured_configs.py).
+- **Config Group**: Config Group is a folder-like structure which allows you to put the config with the same function into a group. The config lives in the same config group and be easily changed modularly.
+- **ConfigStore**: ConfigStore is a singleton which allows you to register you structured config and use them in other yamls and scripts. By using ConfigStore, you can split the defintion and use of a config.
+- **Config Search Path**: If you don't use ConfigStore to register the config(Put a yaml directly there like our `config` folder), Hydra uses config search path to recognize their groups, name and nodes. e.g. in our `config` folder:
+    ```sh
+    .
+    ├── benchmark
+    │   ├── ...
+    └── habitat
+        ├── dataset
+        │   ├── eqa
+        │   ├── imagenav
+        │   ├── instance_imagenav
+        │   ├── objectnav
+        │   ├── pointnav
+        │   ├── ...
+    ```
+    A yaml file can still refer other configs like this(path from the root as group, filename as name):
+    ```yaml
+    defaults:
+        - pointnav_base
+        - /habitat/dataset/pointnav: habitat_test
+        - _self_
+    ```
+    > Habitat adds `habitat/config` to Config Search Path using [`HabitatConfigPlugin`](https://github.com/facebookresearch/habitat-lab/blob/main/habitat-lab/habitat/config/default_structured_configs.py).
+- **Config Injection**: Config injection is used when you want to add a config to a node in current config rather than directly override it. e.g.
+    ```yaml
+    /habitat/simulator/sensor_setups@habitat.simulator.agents.main_agent: rgbds_agent
+    ```
+    This means:
+    ```yaml
+    habitat:
+        simulator:
+            agents:
+                main_agent:
+                    Contents from rgbds_agent
+    ```
+    This will create the node `main_agent` if there is none, and add new contents if some contents already under agents. 
+
+
+## Config Creation Pipeline
+1. Define a sturctured config in script:
+    ```python
+    from dataclasses import dataclass
+    @dataclass
+    class MyConfig:
+        learning_rate: float = 0.001
+        batch_size: int = 32
+        use_gpu: bool = True
+    ```
+2. Register it in ConfigStore
+    ```python
+    from hydra.core.config_store import ConfigStore
+    cs = ConfigStore.instance()
+    cs.store(group="basic_config", name="my_config", node=MyConfig)
+    ```
+3. Refer this in other yaml
+    ```yaml
+    # config.yaml
+    defaults:
+        - basic_config: my_config
+    ```
+    > You use name rather than node to refer.
+4. Use this yaml in your script
+    ```python
+        import hydra
+        from omegaconf import OmegaConf
+
+        @hydra.main(version_base=None, config_name="config")
+        def main(cfg: MyConfig):
+            print(OmegaConf.to_yaml(cfg))
+
+        if __name__ == "__main__":
+            main()
+    ```
+    > Here we use a Hydra way to use this yaml(Decorate the main function), in habitat you typically needn't do this since habitat uses ComposeAPI instead of decorator and you only need to call Habitat API `get_config`.
+
+## Habitat Config Structure
+
+### Benchmark
+
+In Habitat, the `config/benchmark/` directory contains predefined task configurations used for running standardized evaluations or benchmarking models on common datasets and tasks. The config file is typically named by task+dataset(say `pointnav_mp3d.yaml`)
+
+### Habitat
+
+There are 3 subfolders in habitat: `dataset`, `simulator`, `task`.
+
+- `dataset`: Each yaml in `dataset` folder will by default use 
+    ```yaml
+    defaults:
+    - /habitat/dataset: dataset_config_schema
+    - _self_
+    ```
+    which is registered in [default_strucutured_config](https://github.com/facebookresearch/habitat-lab/blob/main/habitat-lab/habitat/config/CONFIG_KEYS.md)
+    and then override `type`, `split`, `data_path`, etc.
+
+- `simulator`: This folder mainly config the agent using default structured config, we can use Config Injection to add sensors and agents.
+- `task`: yaml in `task` folder load `task_config_base` by default, which is a complicated config(see [TaskConfig](https://github.com/facebookresearch/habitat-lab/blob/main/habitat-lab/habitat/config/default_structured_configs.py#L1373)). The important nodes to override are `lab_sensors`, `actions` and `measures`.
+    > `lab_sensors` is different from agent sensors, they provide task level perception, like `habitat.task.lab_sensors.compass_sensor` for angle difference in radians between the current rotation of the robot and the start rotation of the robot along the vertical axis, for more details, see [here](https://github.com/facebookresearch/habitat-lab/blob/main/habitat-lab/habitat/config/CONFIG_KEYS.md).


### PR DESCRIPTION
Add two tutorials for `config` and `action`, remove the HabitatSim dependency in quick_start.py